### PR TITLE
将获取到的直播流地址在potplayer中打开

### DIFF
--- a/src/utils.go
+++ b/src/utils.go
@@ -12,6 +12,13 @@ import (
 	"strings"
 )
 
+func GetPotplayerAddress() string {
+	fmt.Println("请输入Potplayer应用路径，如E:\\PotPlayer\\PotPlayerMini64.exe")
+	var Address string
+	_, _ = fmt.Scanln(&Address)
+	return Address
+}
+
 func GetRealRoomID() int64 {
 	fmt.Println("请输入BiliBili直播间房间号：")
 	var roomID string

--- a/src/v1api.go
+++ b/src/v1api.go
@@ -3,22 +3,24 @@ package bili_live_stream
 import (
 	"fmt"
 	"github.com/tidwall/gjson"
+	"os/exec"
 	"strconv"
 )
 
 const V1API string = "https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl"
 
 func V1Initialization() {
+	potPlayerAddress := GetPotplayerAddress()
 	realRoomID := GetRealRoomID()
 	if realRoomID == -1 {
 		V1FormatInit()
 	}
 	println(strconv.FormatInt(realRoomID, 10))
 	param := map[string]string{"cid": strconv.FormatInt(realRoomID, 10), "platform": "hls"}
-	V1HandlerQualityUrl(GetChooseQuality(param, "data.quality_description", V1API), param)
+	V1HandlerQualityUrl(GetChooseQuality(param, "data.quality_description", V1API), param, potPlayerAddress)
 }
 
-func V1HandlerQualityUrl(qn int64, param map[string]string) {
+func V1HandlerQualityUrl(qn int64, param map[string]string, potPlayerAddress string) {
 	param["qn"] = strconv.FormatInt(qn, 10)
 	result := GetRequest(V1API, param)
 
@@ -40,6 +42,9 @@ func V1HandlerQualityUrl(qn int64, param map[string]string) {
 		fmt.Println(urls[url])
 		content += urls[url] + "\n"
 	}
+
+	cmd := exec.Command(potPlayerAddress, "potplayer://"+content)
+	cmd.Run()
 
 	IsOutput(content)
 }

--- a/src/v2api.go
+++ b/src/v2api.go
@@ -3,22 +3,24 @@ package bili_live_stream
 import (
 	"fmt"
 	"github.com/tidwall/gjson"
+	"os/exec"
 	"strconv"
 )
 
 const V2API string = "https://api.live.bilibili.com/xlive/web-room/v2/index/getRoomPlayInfo"
 
 func V2Initialization() {
+	potplayerAddress := GetPotplayerAddress()
 	realRoomID := GetRealRoomID()
 	if realRoomID == -1 {
 		V2FormatInit()
 	}
 	param := map[string]string{"platform": "h5", "protocol": "0", "format": "0,1,2", "codec": "0", "room_id": strconv.FormatInt(realRoomID, 10)}
 	quality := GetChooseQuality(param, "data.playurl_info.playurl.g_qn_desc", V2API)
-	V2HandlerQualityUrl(quality, param)
+	V2HandlerQualityUrl(quality, param, potplayerAddress)
 }
 
-func V2HandlerQualityUrl(quality int64, param map[string]string) {
+func V2HandlerQualityUrl(quality int64, param map[string]string, potplayerAddress string) {
 	param["qn"] = strconv.FormatInt(quality, 10)
 	result := GetRequest(V2API, param)
 	temp := gjson.Get(result, "data.playurl_info.playurl.stream.0.format.0.codec.0").String()
@@ -30,6 +32,9 @@ func V2HandlerQualityUrl(quality int64, param map[string]string) {
 
 	fmt.Println("视频地址如下：")
 	fmt.Println(realUrl)
+
+	cmd := exec.Command(potplayerAddress, "potplayer://"+realUrl)
+	cmd.Run()
 
 	IsOutput(realUrl)
 }


### PR DESCRIPTION
我不太会找windows的应用注册表，所以只好手动输入
获取的stream连接只有非常短的失效，手动输入大概率无法在potplayer播放